### PR TITLE
[Add] ランキングページのUI実装

### DIFF
--- a/front/public/img/tag/tag-ranking-4below.svg
+++ b/front/public/img/tag/tag-ranking-4below.svg
@@ -1,0 +1,23 @@
+<svg width="144" height="46" viewBox="0 0 144 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="144" height="44" transform="translate(0 1.80005)" fill="#9A9A9A"/>
+<g filter="url(#filter0_d_744_737)">
+<circle cx="72" cy="7.80005" r="3" fill="url(#paint0_linear_744_737)"/>
+</g>
+<defs>
+<filter id="filter0_d_744_737" x="64.2" y="4.86374e-05" width="15.6" height="15.6" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_744_737"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_744_737" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_744_737" x1="72" y1="4.80005" x2="72" y2="10.8" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3C3812"/>
+<stop offset="0.5" stop-color="#A29730"/>
+<stop offset="1" stop-color="#3C3812"/>
+</linearGradient>
+</defs>
+</svg>

--- a/front/public/img/tag/tag-ranking1.svg
+++ b/front/public/img/tag/tag-ranking1.svg
@@ -1,0 +1,28 @@
+<svg width="144" height="47" viewBox="0 0 144 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="144" height="44" transform="translate(0 2.30005)" fill="url(#paint0_linear_744_721)"/>
+<g filter="url(#filter0_d_744_721)">
+<circle cx="72" cy="7.80005" r="3" fill="url(#paint1_linear_744_721)"/>
+</g>
+<defs>
+<filter id="filter0_d_744_721" x="64.2" y="4.86374e-05" width="15.6" height="15.6" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_744_721"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_744_721" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_744_721" x1="72" y1="0" x2="72" y2="44" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CBB745"/>
+<stop offset="0.5" stop-color="#FFF1A3"/>
+<stop offset="1" stop-color="#CBB745"/>
+</linearGradient>
+<linearGradient id="paint1_linear_744_721" x1="72" y1="4.80005" x2="72" y2="10.8" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3C3812"/>
+<stop offset="0.5" stop-color="#A29730"/>
+<stop offset="1" stop-color="#3C3812"/>
+</linearGradient>
+</defs>
+</svg>

--- a/front/public/img/tag/tag-ranking2.svg
+++ b/front/public/img/tag/tag-ranking2.svg
@@ -1,0 +1,28 @@
+<svg width="144" height="47" viewBox="0 0 144 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="144" height="44" transform="translate(0 2.30005)" fill="url(#paint0_linear_744_725)"/>
+<g filter="url(#filter0_d_744_725)">
+<circle cx="72" cy="7.80005" r="3" fill="url(#paint1_linear_744_725)"/>
+</g>
+<defs>
+<filter id="filter0_d_744_725" x="64.2" y="4.86374e-05" width="15.6" height="15.6" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_744_725"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_744_725" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_744_725" x1="72" y1="0" x2="72" y2="44" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BDBDBD"/>
+<stop offset="0.5" stop-color="#EBEBEB"/>
+<stop offset="1" stop-color="#BDBDBD"/>
+</linearGradient>
+<linearGradient id="paint1_linear_744_725" x1="72" y1="4.80005" x2="72" y2="10.8" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3C3812"/>
+<stop offset="0.5" stop-color="#A29730"/>
+<stop offset="1" stop-color="#3C3812"/>
+</linearGradient>
+</defs>
+</svg>

--- a/front/public/img/tag/tag-ranking3.svg
+++ b/front/public/img/tag/tag-ranking3.svg
@@ -1,0 +1,28 @@
+<svg width="144" height="46" viewBox="0 0 144 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="144" height="44" transform="translate(0 1.80005)" fill="url(#paint0_linear_744_729)"/>
+<g filter="url(#filter0_d_744_729)">
+<circle cx="72" cy="7.80005" r="3" fill="url(#paint1_linear_744_729)"/>
+</g>
+<defs>
+<filter id="filter0_d_744_729" x="64.2" y="4.86374e-05" width="15.6" height="15.6" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_744_729"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_744_729" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_744_729" x1="72" y1="0" x2="72" y2="44" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B68634"/>
+<stop offset="0.5" stop-color="#FFDEA5"/>
+<stop offset="1" stop-color="#B68634"/>
+</linearGradient>
+<linearGradient id="paint1_linear_744_729" x1="72" y1="4.80005" x2="72" y2="10.8" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3C3812"/>
+<stop offset="0.5" stop-color="#A29730"/>
+<stop offset="1" stop-color="#3C3812"/>
+</linearGradient>
+</defs>
+</svg>

--- a/front/src/app/rankings/page.tsx
+++ b/front/src/app/rankings/page.tsx
@@ -1,5 +1,39 @@
+import Image from "next/image";
+import rankingsMockData from "@/mocks/rankings.json";
+import { NewspaperCard } from "@/components/layouts";
+
 export default function Rankings() {
   return (
-    <main></main>
+    <main>
+      <div className="flex flex-col items-center gap-6">
+        {rankingsMockData.map((data, i) => {
+          const index = i + 1;
+          
+          return (
+            <div
+              key={data.id}
+              className="flex flex-col items-center gap-6"
+            >
+              <div className="relative w-36 h-11 flex justify-center items-center">
+                <Image
+                  src={`/img/tag/tag-ranking${index <= 3 ? index : "-4below"}.svg`}
+                  alt={`${index}位`}
+                  fill
+                  className="absolute"
+                />
+                <span className="relative z-10 text-black text-xl font-yosugara">
+                  {index}位
+                </span>
+              </div>
+              <NewspaperCard
+                key={data.id}
+                newspaper={data.newspaper}
+                user={data.user}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </main>
   )
 }

--- a/front/src/app/rankings/page.tsx
+++ b/front/src/app/rankings/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import rankingsMockData from "@/mocks/rankings.json";
-import { NewspaperCard } from "@/components/layouts";
+import { NewspaperCard, PostButton } from "@/components/layouts";
 
 export default function Rankings() {
   return (
@@ -34,6 +34,7 @@ export default function Rankings() {
           )
         })}
       </div>
+      <PostButton />
     </main>
   )
 }

--- a/front/src/components/layouts/BottomNav.tsx
+++ b/front/src/components/layouts/BottomNav.tsx
@@ -13,7 +13,7 @@ export function BottomNav() {
                 <Link href="/" className={`flex items-center justify-center h-full w-1/3 ${pathname === '/' ? 'text-red' : 'text-gray'}`}>
                     <Home size={30} />
                 </Link>
-                <Link href="/rankings" className={`flex items-center justify-center h-full w-1/3 ${pathname === '/rapidris' ? 'text-red' : 'text-gray'}`}>
+                <Link href="/rankings" className={`flex items-center justify-center h-full w-1/3 ${pathname === '/rankings' ? 'text-red' : 'text-gray'}`}>
                     <ChartNoAxesCombined size={30} />
                 </Link>
                 <Link href="/profile" className={`flex items-center justify-center h-full w-1/3 ${pathname === '/profile' ? 'text-red' : 'text-gray'}`}>

--- a/front/src/components/layouts/BottomNav.tsx
+++ b/front/src/components/layouts/BottomNav.tsx
@@ -8,7 +8,7 @@ import { Home,ChartNoAxesCombined,CircleUser } from "lucide-react";
 export function BottomNav() {
     const pathname = usePathname();
     return (
-        <div className="fixed bottom-0 w-full h-17.5 bg-white shadow-2xl">
+        <div className="fixed bottom-0 w-full h-17.5 bg-white shadow-2xl z-50">
             <div className="flex w-full h-full">
                 <Link href="/" className={`flex items-center justify-center h-full w-1/3 ${pathname === '/' ? 'text-red' : 'text-gray'}`}>
                     <Home size={30} />

--- a/front/src/components/layouts/NewspaperCard.tsx
+++ b/front/src/components/layouts/NewspaperCard.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Newspaper,User} from "../../types/newspaper"; 
+import { Newspaper, User } from "@/types/newspaper";
+import { ChevronRight } from "lucide-react";
 
 interface NewspaperCardProps {
     newspaper: Newspaper;
@@ -33,10 +34,17 @@ export function NewspaperCard({ newspaper, user }: NewspaperCardProps) {
                 <p className="text-black text-md font-bold">{displayTitle}</p>
                 <p className="text-gray text-sm font-md">{displayDescription}</p>
                 {isLongDescription && (
-                    <Link href={`/news-paper/${newspaper.id}`}>
+                    <Link 
+                        href={`/news-paper/${newspaper.id}`}
+                        className="flex items-center"
+                    >
                         <button className="text-red text-sm font-bold mt-1 hover:underline">
                             もっとみる 
                         </button>
+                        <ChevronRight 
+                            size={20}
+                            color="#D3141B"
+                        />
                     </Link>
                 )}
             </div>

--- a/front/src/mocks/rankings.json
+++ b/front/src/mocks/rankings.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": 1,
+    "newspaper": {
+      "id": 201,
+      "title": "SNSで話題沸騰！新感覚スイーツ登場",
+      "description": "発売直後からSNSで爆発的に拡散された新作スイーツ。行列必至の人気ぶりで、各メディアでも取り上げられています。",
+      "images": "/img/dummy-img.svg",
+      "likes": 3120,
+      "is_liked": true
+    },
+    "user": {
+      "id": 21,
+      "name": "石田遥",
+      "icon_url": "/img/dummy-img.svg"
+    }
+  },
+  {
+    "id": 2,
+    "newspaper": {
+      "id": 202,
+      "title": "急上昇！話題の新作映画レビュー",
+      "description": "公開直後から口コミで人気が急上昇している新作映画。感動のストーリーと圧巻の映像美が高評価を集めています。",
+      "images": "/img/dummy-img.svg",
+      "likes": 2895,
+      "is_liked": false
+    },
+    "user": {
+      "id": 22,
+      "name": "村上大輔",
+      "icon_url": "/img/dummy-img.svg"
+    }
+  },
+  {
+    "id": 3,
+    "newspaper": {
+      "id": 203,
+      "title": "新星アーティスト、音楽チャート急浮上",
+      "description": "デビュー間もないアーティストが音楽チャートで急上昇。独自のサウンドと世界観が若者を中心に支持を集めています。",
+      "images": "/img/dummy-img.svg",
+      "likes": 2541,
+      "is_liked": true
+    },
+    "user": {
+      "id": 23,
+      "name": "山口葵",
+      "icon_url": "/img/dummy-img.svg"
+    }
+  },
+  {
+    "id": 4,
+    "newspaper": {
+      "id": 204,
+      "title": "急上昇中！最新ガジェット特集",
+      "description": "発売直後から売り切れ続出の最新ガジェット。便利な機能とスタイリッシュなデザインが人気の理由です。",
+      "images": "/img/dummy-img.svg",
+      "likes": 1987,
+      "is_liked": false
+    },
+    "user": {
+      "id": 24,
+      "name": "佐々木健",
+      "icon_url": "/img/dummy-img.svg"
+    }
+  },
+  {
+    "id": 5,
+    "newspaper": {
+      "id": 205,
+      "title": "注目度急上昇！話題のスポット",
+      "description": "最近SNSで急速に注目を集めている観光スポット。写真映えする景色やユニークな体験が人気の理由です。",
+      "images": "/img/dummy-img.svg",
+      "likes": 1764,
+      "is_liked": true
+    },
+    "user": {
+      "id": 25,
+      "name": "藤本優",
+      "icon_url": "/img/dummy-img.svg"
+    }
+  }
+]


### PR DESCRIPTION
# やったこと🎖️

## 新規の追加点
- ランキングページのUI実装
- 急上昇ランキング用のモックデータを追加

## 修正・変更点
- `BottomNav`コンポーネントのスタイルを切り替える条件文で、`rapidris`から`rankings`に変更
- `BottomNav`コンポーネントに`z-50`を追加して要素の最上部に表示されるように変更
- `NewspaperCard`コンポーネントの「もっと見る」の隣に矢印を配置

## 次にやること
- 投稿詳細ページのUI実装
- 睡眠

<br />

---

<br />

## 実際の画面

<img width="190" height="404" alt="スクリーンショット 2026-01-28 4 13 29" src="https://github.com/user-attachments/assets/509006a2-70a8-4fe4-a99a-b606bdeecd7d" />

